### PR TITLE
fix: mamsc v1.0.2 cannot be installed with yarn, but doesnt bring any…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
 	"author": "Christian Volmering <christian@volmering.name>",
 	"license": "MIT",
 	"dependencies": {
-		"mamsc": "^1.0.1"
+		"mamsc": "1.0.1"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-mamsc@^1.0.1:
+mamsc@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mamsc/-/mamsc-1.0.1.tgz#a5a95197f1980b5790fa0305228242d8ffaa42fc"
   integrity sha512-dgRc3huYtyIEl+zS8VVlecyCa5DU6Lf26uuTsBe28vZ9kUlmq3pAu1OGkWbUhkE82q9xoEMjogz+KmKN5Sgpxw==


### PR DESCRIPTION
… code changes so pin to v1.0.1